### PR TITLE
ci: install Poetry via pip; stabilize Python jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,10 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Poetry
-        run: pipx install poetry==1.8.3
+        run: |
+          python -m pip install --upgrade pip
+          pip install "poetry==1.8.3"
+          poetry --version
       - name: Install deps
         run: poetry install --no-interaction
       - name: Ruff
@@ -82,7 +85,10 @@ jobs:
         with:
           python-version: "3.12"
       - name: Install Poetry
-        run: pipx install poetry==1.8.3
+        run: |
+          python -m pip install --upgrade pip
+          pip install "poetry==1.8.3"
+          poetry --version
       - name: Install deps
         run: poetry install --no-interaction
       - name: Pytest


### PR DESCRIPTION
Move CI to Poetry via pip for stable runners. Mirrors local green gate.