### PR TITLE
docs: add CI result reading

### DIFF
--- a/docs/collab/03-ci-reading-ci-result-reading.md
+++ b/docs/collab/03-ci-reading-ci-result-reading.md
@@ -1,0 +1,9 @@
+# CI result reading
+
+Adds a short note about reading CI results before merging.
+
+## Notes
+
+- Keep the change small.
+- Review the diff before merging.
+- Prefer clear intent over large mixed changes.


### PR DESCRIPTION
Adds a short note about reading CI results before merging.