### PR TITLE
docs: add contribution checklist

### DIFF
--- a/docs/contribution-checklist.md
+++ b/docs/contribution-checklist.md
@@ -1,0 +1,18 @@
+# Contribution checklist
+
+Use this checklist before opening small documentation or template pull requests.
+
+## Before committing
+
+- Keep the change focused.
+- Avoid unrelated formatting edits.
+- Check that no secrets, tokens, logs or private data were added.
+- Prefer small commits with clear messages.
+- Explain why the change helps future maintainers.
+
+## Before opening the pull request
+
+- Review the final diff.
+- Confirm that the branch name matches the scope.
+- Confirm that the pull request body describes the change clearly.
+- Keep screenshots or logs out of the repository unless they are intentionally curated.


### PR DESCRIPTION
Adds a small contribution checklist for documentation and template changes.

Scope:
- documentation only
- no secrets
- no personal data
- no system changes