### PR TITLE
docs: add release checklist

### DIFF
--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -1,0 +1,18 @@
+# Release checklist
+
+Use this checklist before preparing a small release or version update.
+
+## Before release
+
+- Confirm that the main branch is up to date.
+- Review the latest merged changes.
+- Check that CI has passed on the release candidate.
+- Confirm that the changelog or release notes match the actual changes.
+- Avoid mixing unrelated fixes into the release branch.
+
+## Before publishing
+
+- Review package metadata.
+- Confirm that version numbers are consistent.
+- Check that no secrets, tokens, logs or private data were added.
+- Keep the release notes clear, short and useful.


### PR DESCRIPTION
Adds a small release checklist for documentation and template maintenance.

Scope:
- documentation only
- no secrets
- no personal data
- no system changes