### PR TITLE
docs: add local review guide

### DIFF
--- a/docs/local-review-guide.md
+++ b/docs/local-review-guide.md
@@ -1,0 +1,18 @@
+# Local review guide
+
+Use this guide before opening small local changes as pull requests.
+
+## Local checks
+
+- Review the changed files before committing.
+- Keep each branch focused on one small topic.
+- Avoid committing temporary files or editor backups.
+- Check that documentation examples remain generic.
+- Confirm that no secrets, tokens, logs or private data were added.
+
+## Pull request review
+
+- Use a clear title.
+- Describe the intent in a short body.
+- Confirm that CI has passed before merge.
+- Keep unrelated follow-up work in a separate pull request.


### PR DESCRIPTION
Adds a small local review guide for documentation and template changes.

Scope:
- documentation only
- no secrets
- no personal data
- no system changes