### PR TITLE
docs: add issue triage checklist

### DIFF
--- a/docs/issue-triage-checklist.md
+++ b/docs/issue-triage-checklist.md
@@ -1,0 +1,18 @@
+# Issue triage checklist
+
+Use this checklist when reviewing small issues before turning them into pull requests.
+
+## Triage steps
+
+- Confirm that the issue describes a real maintenance need.
+- Check whether the change belongs in documentation, tests or code.
+- Keep the first response clear and practical.
+- Avoid expanding the scope before the first fix is understood.
+- Link related pull requests when useful.
+
+## Before implementation
+
+- Choose a small branch name.
+- Define the expected changed files.
+- Confirm that no secrets, tokens, logs or private data are needed.
+- Leave broad redesigns for a separate discussion.


### PR DESCRIPTION
Adds a small issue triage checklist for documentation and template maintenance.

Scope:
- documentation only
- no secrets
- no personal data
- no system changes