### PR TITLE
docs: add template usage notes

### DIFF
--- a/docs/template-usage-notes.md
+++ b/docs/template-usage-notes.md
@@ -1,0 +1,18 @@
+# Template usage notes
+
+Use these notes when adapting this template for a new project.
+
+## Before adapting
+
+- Start from a clean branch.
+- Review the default project structure.
+- Keep project-specific changes separate from template maintenance.
+- Replace placeholders with accurate project information.
+- Avoid copying secrets, logs or private configuration into the repository.
+
+## Before opening a pull request
+
+- Review the changed file list.
+- Confirm that the documentation matches the intended project use.
+- Keep unrelated cleanup in a separate pull request.
+- Make the pull request body short and specific.


### PR DESCRIPTION
Adds small template usage notes for documentation and project setup.

Scope:
- documentation only
- no secrets
- no personal data
- no system changes