### PR TITLE
docs: add merge safety notes

### DIFF
--- a/docs/merge-safety-notes.md
+++ b/docs/merge-safety-notes.md
@@ -1,0 +1,23 @@
+# Merge safety notes
+
+Use these notes before merging a small pull request.
+
+## Before merge
+
+- Confirm that the pull request is open and not a draft.
+- Confirm that the reviewed commit is still the current pull request head.
+- Confirm that the change has the expected approval.
+- Confirm that configured checks are complete.
+
+## Merge discipline
+
+- Do not merge unrelated changes together.
+- Do not merge when the branch changed after review.
+- Do not merge when the pull request scope is unclear.
+- Do not merge when required checks are missing or still pending.
+
+## After merge
+
+- Confirm that the pull request is closed as merged.
+- Confirm that the main branch includes the merge commit.
+- Keep the merge history understandable for future review.


### PR DESCRIPTION
Adds small merge safety notes for documentation and template maintenance.

Scope:
- documentation only
- no secrets
- no personal data
- no system changes