### PR TITLE
docs: add post-merge checklist

### DIFF
--- a/docs/post-merge-checklist.md
+++ b/docs/post-merge-checklist.md
@@ -1,0 +1,23 @@
+# Post-merge checklist
+
+Use this checklist after a small pull request has been merged.
+
+## Confirm merge state
+
+- Confirm that the pull request is closed as merged.
+- Confirm that the main branch contains the merged change.
+- Confirm that the merge commit is visible in the upstream repository.
+- Confirm that no follow-up fix is needed immediately.
+
+## Local cleanup
+
+- Update the local main branch from upstream main.
+- Remove the merged feature branch only after verification.
+- Leave unrelated local branches untouched.
+- Check that no untracked files remain from the work.
+
+## Follow-up notes
+
+- Record any useful lesson from the review.
+- Keep follow-up work in a new branch.
+- Do not mix cleanup with the next feature branch.


### PR DESCRIPTION
Adds a small post-merge checklist for documentation and template maintenance.

Scope:
- documentation only
- no secrets
- no personal data
- no system changes