### PR TITLE
docs: add session handoff notes

### DIFF
--- a/docs/session-handoff-notes.md
+++ b/docs/session-handoff-notes.md
@@ -1,0 +1,24 @@
+# Session handoff notes
+
+Use these notes when handing off repository maintenance between contributors.
+
+## Handoff context
+
+- State which pull request was last merged.
+- State which branch is currently active.
+- State whether the local working tree is clean.
+- State whether any follow-up work is intentionally pending.
+
+## Safety checks
+
+- Do not assume the next contributor has local context.
+- Do not leave untracked files without explaining them.
+- Do not start new work from an outdated branch.
+- Do not mix handoff notes with unrelated repository changes.
+
+## Next session
+
+- Fetch the upstream main branch first.
+- Start a new branch for the next focused change.
+- Keep the next change small enough to review.
+- Preserve a clear trail for future maintainers.


### PR DESCRIPTION
Adds small session handoff notes for documentation and template maintenance.

Scope:
- documentation only
- no secrets
- no personal data
- no system changes