### PR TITLE
docs: add release handoff notes

### DIFF
--- a/docs/release-handoff-notes.md
+++ b/docs/release-handoff-notes.md
@@ -1,0 +1,24 @@
+# Release handoff notes
+
+Use these notes when handing off a small release or maintenance update.
+
+## Release context
+
+- State which change was last merged.
+- State whether the release is documentation-only or code-related.
+- State whether any checks are still pending.
+- State whether follow-up work is required.
+
+## Before handoff
+
+- Confirm that the main branch is up to date.
+- Confirm that the pull request trail is understandable.
+- Confirm that no local-only files are needed.
+- Confirm that no secrets or personal data were included.
+
+## Next maintainer
+
+- Start from the current upstream main branch.
+- Open a new branch for any follow-up work.
+- Keep the next change separate from the previous release.
+- Document anything that cannot be verified immediately.


### PR DESCRIPTION
Adds small release handoff notes for documentation and template maintenance.

Scope:
- documentation only
- no secrets
- no personal data
- no system changes