### PR TITLE
docs: add issue review notes

### DIFF
--- a/docs/issue-review-notes.md
+++ b/docs/issue-review-notes.md
@@ -1,0 +1,24 @@
+# Issue review notes
+
+Use these notes when reviewing small issue reports or maintenance requests.
+
+## Initial review
+
+- Confirm that the issue describes one clear problem.
+- Confirm that the expected behavior is understandable.
+- Confirm that the reported context is enough to start triage.
+- Confirm that no secrets or personal data were included.
+
+## Triage focus
+
+- Separate confirmed facts from assumptions.
+- Ask for missing reproduction steps when needed.
+- Avoid expanding the issue into unrelated work.
+- Link follow-up pull requests only when they directly address the issue.
+
+## Closing notes
+
+- Close issues only when the resolution is clear.
+- Record the pull request or commit that resolved the issue.
+- Leave unresolved risks visible instead of hiding them.
+- Keep the issue history useful for future maintainers.


### PR DESCRIPTION
Adds small issue review notes for documentation and template maintenance.

Scope:
- documentation only
- no secrets
- no personal data
- no system changes