### PR TITLE
docs: add triage handoff notes

### DIFF
--- a/docs/triage-handoff-notes.md
+++ b/docs/triage-handoff-notes.md
@@ -1,0 +1,24 @@
+# Triage handoff notes
+
+Use these notes when handing off issue or pull request triage.
+
+## Handoff summary
+
+- State which item was reviewed last.
+- State whether the item is blocked or ready.
+- State what evidence was checked.
+- State what still needs verification.
+
+## Safe handoff
+
+- Do not assume the next reviewer saw the same context.
+- Do not hide uncertainty in confident wording.
+- Do not close or merge when the next step is unclear.
+- Do not mix unrelated triage decisions in one handoff.
+
+## Next reviewer
+
+- Recheck the current repository state.
+- Read the latest comments before acting.
+- Confirm that the branch or issue still exists.
+- Leave a short note when the decision changes.


### PR DESCRIPTION
Adds small triage handoff notes for documentation and template maintenance.

Scope:
- documentation only
- no secrets
- no personal data
- no system changes