### PR TITLE
docs: add maintenance handoff checklist

### DIFF
--- a/docs/maintenance-handoff-checklist.md
+++ b/docs/maintenance-handoff-checklist.md
@@ -1,0 +1,24 @@
+# Maintenance handoff checklist
+
+Use this checklist when handing off small repository maintenance work.
+
+## Current state
+
+- State the last merged pull request.
+- State the current main branch commit.
+- State whether the working tree is clean.
+- State whether any local branches still need attention.
+
+## Handoff quality
+
+- Explain what was verified.
+- Explain what was intentionally left untouched.
+- Explain what should be checked before the next change.
+- Avoid relying on private chat context as the only record.
+
+## Next action
+
+- Fetch upstream main before starting.
+- Create a focused branch for the next change.
+- Keep the next pull request small and auditable.
+- Verify the final diff before requesting review.


### PR DESCRIPTION
Adds a small maintenance handoff checklist for documentation and template maintenance.

Scope:
- documentation only
- no secrets
- no personal data
- no system changes