### PR TITLE
docs: add final review checklist

### DIFF
--- a/docs/final-review-checklist.md
+++ b/docs/final-review-checklist.md
@@ -1,0 +1,24 @@
+# Final review checklist
+
+Use this checklist before closing a small maintenance session.
+
+## Repository state
+
+- Confirm that the last pull request was merged.
+- Confirm that the main branch is current.
+- Confirm that the working tree is clean.
+- Confirm that the fork is synchronized when needed.
+
+## Review trail
+
+- Confirm that recent pull requests have clear titles.
+- Confirm that commits have useful messages.
+- Confirm that documentation changes are scoped and auditable.
+- Confirm that no secrets or personal data were added.
+
+## Closing step
+
+- Leave follow-up work for a new branch.
+- Do not delete useful history too early.
+- Do not continue adding changes after the session is complete.
+- Stop when the repository is clean and understandable.


### PR DESCRIPTION
Adds a small final review checklist for documentation and template maintenance.

Scope:
- documentation only
- no secrets
- no personal data
- no system changes