### PR TITLE
docs: add review closeout notes

### DIFF
--- a/docs/review-closeout-notes.md
+++ b/docs/review-closeout-notes.md
@@ -1,0 +1,24 @@
+# Review closeout notes
+
+Use these notes when closing a small review session.
+
+## Before closing
+
+- Confirm that the latest pull request was merged.
+- Confirm that the reviewed branch is no longer active.
+- Confirm that the working tree is clean.
+- Confirm that no untracked files were left behind.
+
+## Closeout quality
+
+- Record what was verified.
+- Leave follow-up work for a new branch.
+- Do not mix closeout cleanup with new changes.
+- Keep the repository state easy to understand.
+
+## Next session
+
+- Start from the current upstream main branch.
+- Recheck open pull requests before creating new work.
+- Keep the next change focused and auditable.
+- Preserve a clear trail for maintainers.


### PR DESCRIPTION
Adds small review closeout notes for documentation and template maintenance.

Scope:
- documentation only
- no secrets
- no personal data
- no system changes