### PR TITLE
docs: add session reset checklist

### DIFF
--- a/docs/session-reset-checklist.md
+++ b/docs/session-reset-checklist.md
@@ -1,0 +1,24 @@
+# Session reset checklist
+
+Use this checklist when restarting repository work after a break.
+
+## Before work
+
+- Fetch the current upstream main branch.
+- Confirm that the local main branch matches upstream main.
+- Confirm that the working tree is clean.
+- Confirm that no previous task branch is still active.
+
+## Session focus
+
+- Choose one small maintenance goal.
+- Create one branch for that goal.
+- Keep the change limited to documentation or the planned file.
+- Avoid mixing cleanup with new work.
+
+## Before review
+
+- Check the diff before committing.
+- Confirm that no secrets or personal data were added.
+- Confirm that the commit message matches the change.
+- Open one focused pull request for review.


### PR DESCRIPTION
Adds a small session reset checklist for documentation and template maintenance.

Scope:
- documentation only
- no secrets
- no personal data
- no system changes