### PR TITLE
docs: add repository health notes

### DIFF
--- a/docs/repository-health-notes.md
+++ b/docs/repository-health-notes.md
@@ -1,0 +1,24 @@
+# Repository health notes
+
+Use these notes to keep small maintenance work easy to review.
+
+## Healthy state
+
+- The main branch is current.
+- The working tree is clean.
+- Open pull requests have clear scope.
+- Recent changes are small enough to audit.
+
+## Review signals
+
+- File names describe the purpose of the change.
+- Documentation updates avoid private context.
+- Commit messages match the actual diff.
+- Follow-up work is not mixed into the current branch.
+
+## Maintenance habits
+
+- Start each task from upstream main.
+- Keep one goal per branch.
+- Review the diff before pushing.
+- Stop after the repository is clean and understandable.


### PR DESCRIPTION
Adds small repository health notes for documentation and template maintenance.

Scope:
- documentation only
- no secrets
- no personal data
- no system changes