### PR TITLE
docs: add review readiness checklist

### DIFF
--- a/docs/review-readiness-checklist.md
+++ b/docs/review-readiness-checklist.md
@@ -1,0 +1,24 @@
+# Review readiness checklist
+
+Use this checklist before opening a small pull request.
+
+## Branch state
+
+- Confirm that the branch starts from the current upstream main.
+- Confirm that the branch name matches the planned change.
+- Confirm that the working tree contains only expected files.
+- Confirm that no unrelated cleanup was included.
+
+## Content state
+
+- Confirm that the documentation is clear.
+- Confirm that the change avoids private context.
+- Confirm that no secrets or personal data were added.
+- Confirm that the file name describes the purpose.
+
+## Pull request state
+
+- Use a short and accurate title.
+- Keep the body focused on scope.
+- Mention that the change is documentation only.
+- Request review only after checking the final diff.


### PR DESCRIPTION
Adds a small review readiness checklist for documentation and template maintenance.

Scope:
- documentation only
- no secrets
- no personal data
- no system changes