### PR TITLE
docs: add follow-up boundary notes

### DIFF
--- a/docs/follow-up-boundary-notes.md
+++ b/docs/follow-up-boundary-notes.md
@@ -1,0 +1,24 @@
+# Follow-up boundary notes
+
+Use these notes to keep follow-up work separate from completed changes.
+
+## Boundary
+
+- Do not extend a merged pull request with unrelated work.
+- Do not reuse a branch for a different topic.
+- Do not mix cleanup, documentation, and feature work without a clear reason.
+- Do not rely on memory alone for the next task.
+
+## Follow-up handling
+
+- Write down the next idea separately.
+- Start a new branch from the current upstream main.
+- Keep the next pull request small.
+- Make the review path easy to follow.
+
+## Closeout
+
+- Confirm that the current task is complete.
+- Confirm that the repository state is clean.
+- Confirm that no temporary files remain.
+- Leave the next task for a new review cycle.


### PR DESCRIPTION
Adds small follow-up boundary notes for documentation and template maintenance.

Scope:
- documentation only
- no secrets
- no personal data
- no system changes