### PR TITLE
docs: add merge readiness notes

### DIFF
--- a/docs/merge-readiness-notes.md
+++ b/docs/merge-readiness-notes.md
@@ -1,0 +1,24 @@
+# Merge readiness notes
+
+Use these notes before merging a small reviewed pull request.
+
+## Required state
+
+- Confirm that the pull request is open.
+- Confirm that the branch is current enough for review.
+- Confirm that checks completed successfully.
+- Confirm that the intended reviewer approved the change.
+
+## Merge safety
+
+- Confirm that the head commit matches the expected commit.
+- Confirm that the pull request contains only expected files.
+- Confirm that the change is documentation only when that is the stated scope.
+- Confirm that no secrets or personal data were added.
+
+## After merge
+
+- Confirm that the pull request is closed as merged.
+- Confirm that main contains the merge commit.
+- Confirm that follow-up work remains separate.
+- Leave cleanup for a verified closeout step.


### PR DESCRIPTION
Adds small merge readiness notes for documentation and template maintenance.

Scope:
- documentation only
- no secrets
- no personal data
- no system changes