### PR TITLE
docs: add closeout readiness notes

### DIFF
--- a/docs/closeout-readiness-notes.md
+++ b/docs/closeout-readiness-notes.md
@@ -1,0 +1,24 @@
+# Closeout readiness notes
+
+Use these notes before ending a small maintenance cycle.
+
+## Final state
+
+- Confirm that the last pull request was merged.
+- Confirm that main contains the expected merge commit.
+- Confirm that the local repository is back on main.
+- Confirm that the fork main branch is synchronized when needed.
+
+## Review record
+
+- Keep the pull request title accurate.
+- Keep the change history easy to follow.
+- Keep follow-up ideas outside the completed branch.
+- Keep private context out of repository documentation.
+
+## Stop condition
+
+- Stop when the repository is clean.
+- Stop when the intended change is merged.
+- Stop before adding unrelated improvements.
+- Leave the next task for a new branch and review.


### PR DESCRIPTION
Adds small closeout readiness notes for documentation and template maintenance.

Scope:
- documentation only
- no secrets
- no personal data
- no system changes