### PR TITLE
docs: add session continuity notes

### DIFF
--- a/docs/session-continuity-notes.md
+++ b/docs/session-continuity-notes.md
@@ -1,0 +1,24 @@
+# Session continuity notes
+
+Use these notes when continuing repository work across multiple sessions.
+
+## Starting point
+
+- Confirm the latest merged pull request.
+- Confirm the current upstream main branch.
+- Confirm that the local main branch is clean.
+- Confirm that no previous branch is still active.
+
+## Continuity
+
+- Keep the next change small.
+- Keep the next branch focused on one purpose.
+- Keep private chat context out of repository files.
+- Keep follow-up ideas separate from the active change.
+
+## Before review
+
+- Check the final diff.
+- Confirm that only expected files changed.
+- Confirm that no secrets or personal data were added.
+- Open one pull request for the focused change.


### PR DESCRIPTION
Adds small session continuity notes for documentation and template maintenance.

Scope:
- documentation only
- no secrets
- no personal data
- no system changes