### PR TITLE
docs: add maintenance checkpoint notes

### DIFF
--- a/docs/maintenance-checkpoint-notes.md
+++ b/docs/maintenance-checkpoint-notes.md
@@ -1,0 +1,24 @@
+# Maintenance checkpoint notes
+
+Use these notes to record a clean checkpoint during repository maintenance.
+
+## Checkpoint state
+
+- Confirm the latest upstream main commit.
+- Confirm that the local main branch is clean.
+- Confirm that the active branch has one clear purpose.
+- Confirm that no unrelated files are included.
+
+## Review checkpoint
+
+- Check the diff before pushing.
+- Check that the commit message matches the change.
+- Check that the pull request body states the scope.
+- Check that no secrets or personal data were added.
+
+## Continuation
+
+- Keep future work on a new branch.
+- Keep completed work separate from new ideas.
+- Keep the repository easy to audit.
+- Stop when the current checkpoint is clean.


### PR DESCRIPTION
Adds small maintenance checkpoint notes for documentation and template maintenance.

Scope:
- documentation only
- no secrets
- no personal data
- no system changes