### PR TITLE
docs: add review cycle notes

### DIFF
--- a/docs/review-cycle-notes.md
+++ b/docs/review-cycle-notes.md
@@ -1,0 +1,24 @@
+# Review cycle notes
+
+Use these notes to keep a small review cycle clear and auditable.
+
+## Cycle start
+
+- Confirm that main is current.
+- Confirm that the working tree is clean.
+- Confirm that the branch has one focused purpose.
+- Confirm that the planned change is small.
+
+## During review
+
+- Keep the pull request body short and accurate.
+- Keep the diff limited to expected files.
+- Keep private context out of repository documentation.
+- Keep unrelated ideas for a later branch.
+
+## Cycle end
+
+- Confirm that checks completed successfully.
+- Confirm that the pull request was reviewed.
+- Confirm that the merge was intentional.
+- Confirm that follow-up work stays separate.


### PR DESCRIPTION
Adds small review cycle notes for documentation and template maintenance.

Scope:
- documentation only
- no secrets
- no personal data
- no system changes