### PR TITLE
docs: add reviewer context notes

### DIFF
--- a/docs/reviewer-context-notes.md
+++ b/docs/reviewer-context-notes.md
@@ -1,0 +1,24 @@
+# Reviewer context notes
+
+Use these notes to give reviewers enough context for a small documentation change.
+
+## Context
+
+- State the purpose of the change.
+- State why the change belongs in documentation.
+- State which file was added or updated.
+- State whether the change affects runtime behavior.
+
+## Review focus
+
+- Check that the wording is clear.
+- Check that the scope matches the pull request title.
+- Check that no private context was added.
+- Check that no secrets or personal data were added.
+
+## Follow-up
+
+- Keep unrelated ideas out of the current pull request.
+- Move larger changes into a separate branch.
+- Leave the final decision visible in the review trail.
+- Close the cycle when the change is merged.


### PR DESCRIPTION
Adds small reviewer context notes for documentation and template maintenance.

Scope:
- documentation only
- no secrets
- no personal data
- no system changes