### PR TITLE
docs: add small change checklist

### DIFF
--- a/docs/small-change-checklist.md
+++ b/docs/small-change-checklist.md
@@ -1,0 +1,24 @@
+# Small change checklist
+
+Use this checklist before making a small repository maintenance change.
+
+## Planning
+
+- Choose one clear change.
+- Confirm that the change belongs in the repository.
+- Confirm that the branch name describes the work.
+- Confirm that the change can be reviewed quickly.
+
+## Editing
+
+- Touch only the expected files.
+- Keep documentation wording direct.
+- Avoid private context and local machine details.
+- Avoid unrelated cleanup.
+
+## Review
+
+- Check the diff before committing.
+- Confirm that no secrets or personal data were added.
+- Confirm that the pull request title matches the change.
+- Leave follow-up work for a separate branch.


### PR DESCRIPTION
Adds a small change checklist for documentation and template maintenance.

Scope:
- documentation only
- no secrets
- no personal data
- no system changes