### PR TITLE
docs: add repository closeout checklist

### DIFF
--- a/docs/repository-closeout-checklist.md
+++ b/docs/repository-closeout-checklist.md
@@ -1,0 +1,24 @@
+# Repository closeout checklist
+
+Use this checklist before ending a repository maintenance session.
+
+## Final repository state
+
+- Confirm that the latest pull request was merged.
+- Confirm that main contains the expected merge commit.
+- Confirm that the local main branch is current.
+- Confirm that the working tree is clean.
+
+## Review record
+
+- Confirm that the pull request title matched the change.
+- Confirm that the body stated the documentation-only scope.
+- Confirm that no secrets or personal data were added.
+- Confirm that follow-up work was left for another branch.
+
+## Stop point
+
+- Stop when the intended change is complete.
+- Stop before adding unrelated improvements.
+- Leave the repository ready for the next session.
+- Keep the final state easy to audit.


### PR DESCRIPTION
Adds a small repository closeout checklist for documentation and template maintenance.

Scope:
- documentation only
- no secrets
- no personal data
- no system changes