### PR TITLE
docs: add session finalization notes

### DIFF
--- a/docs/session-finalization-notes.md
+++ b/docs/session-finalization-notes.md
@@ -1,0 +1,24 @@
+# Session finalization notes
+
+Use these notes to finalize a small repository maintenance session.
+
+## Final check
+
+- Confirm that the latest pull request was merged.
+- Confirm that main contains the expected merge commit.
+- Confirm that the local main branch is current.
+- Confirm that the working tree is clean.
+
+## Session record
+
+- Keep the review trail easy to follow.
+- Keep the final change documentation only when stated.
+- Keep private context out of repository files.
+- Keep secrets and personal data out of the diff.
+
+## Next session
+
+- Start from the current upstream main branch.
+- Create a new branch for the next focused change.
+- Keep follow-up work separate.
+- Stop when the repository is clean and understandable.


### PR DESCRIPTION
Adds small session finalization notes for documentation and template maintenance.

Scope:
- documentation only
- no secrets
- no personal data
- no system changes