### PR TITLE
docs: add daily maintenance plan

### DIFF
--- a/docs/daily-maintenance-plan.md
+++ b/docs/daily-maintenance-plan.md
@@ -1,0 +1,24 @@
+# Daily maintenance plan
+
+Use this plan when doing a focused repository maintenance session.
+
+## Start
+
+- Confirm that upstream main is current.
+- Confirm that the local main branch is clean.
+- Confirm that the next branch has one clear purpose.
+- Confirm that the planned change is small.
+
+## Work
+
+- Keep the change limited to expected files.
+- Keep documentation wording clear and direct.
+- Keep private context out of repository files.
+- Keep secrets and personal data out of the diff.
+
+## Finish
+
+- Open one focused pull request.
+- Wait for checks before merging.
+- Keep follow-up ideas for another branch.
+- Stop when the repository is clean and understandable.


### PR DESCRIPTION
Adds a small daily maintenance plan for documentation and template maintenance.

Scope:
- documentation only
- no secrets
- no personal data
- no system changes