### PR TITLE
docs: add pull request handoff plan

### DIFF
--- a/docs/pull-request-handoff-plan.md
+++ b/docs/pull-request-handoff-plan.md
@@ -1,0 +1,24 @@
+# Pull request handoff plan
+
+Use this plan when handing a small pull request to a reviewer.
+
+## Before handoff
+
+- Confirm that the branch starts from upstream main.
+- Confirm that the pull request has one clear purpose.
+- Confirm that the diff contains only expected files.
+- Confirm that the commit message matches the change.
+
+## Review handoff
+
+- State that the change is documentation only.
+- State that no secrets or personal data were added.
+- State what file was added or updated.
+- Keep the pull request body short and useful.
+
+## After review
+
+- Wait for checks before merging.
+- Merge only after approval.
+- Keep follow-up work in a new branch.
+- Leave the review trail easy to audit.


### PR DESCRIPTION
Adds a small pull request handoff plan for documentation and template maintenance.

Scope:
- documentation only
- no secrets
- no personal data
- no system changes