### PR TITLE
docs: add maintenance review plan

### DIFF
--- a/docs/maintenance-review-plan.md
+++ b/docs/maintenance-review-plan.md
@@ -1,0 +1,24 @@
+# Maintenance review plan
+
+Use this plan when reviewing a small repository maintenance change.
+
+## Review start
+
+- Confirm that the pull request has one clear purpose.
+- Confirm that the branch name matches the change.
+- Confirm that the changed file is expected.
+- Confirm that the scope is documentation only when stated.
+
+## Review checks
+
+- Check that the wording is clear and direct.
+- Check that no private context was added.
+- Check that no secrets or personal data were added.
+- Check that the commit message matches the diff.
+
+## Review close
+
+- Wait for checks before merging.
+- Confirm that approval is intentional.
+- Keep follow-up work in a separate branch.
+- Leave the repository easy to audit.


### PR DESCRIPTION
Adds a small maintenance review plan for documentation and template maintenance.

Scope:
- documentation only
- no secrets
- no personal data
- no system changes