### PR TITLE
docs: add clean handoff checklist

### DIFF
--- a/docs/clean-handoff-checklist.md
+++ b/docs/clean-handoff-checklist.md
@@ -1,0 +1,24 @@
+# Clean handoff checklist
+
+Use this checklist when handing off a small repository change.
+
+## Before handoff
+
+- Confirm that the branch starts from current upstream main.
+- Confirm that the change has one clear purpose.
+- Confirm that only expected files changed.
+- Confirm that the working tree is clean before push.
+
+## Handoff details
+
+- State that the change is documentation only.
+- State which file was added or updated.
+- State that no secrets or personal data were added.
+- Keep private context out of repository documentation.
+
+## After handoff
+
+- Wait for checks before merge.
+- Keep follow-up work in a separate branch.
+- Confirm that the merge uses the expected head commit.
+- Leave the repository ready for the next focused task.


### PR DESCRIPTION
Adds a small clean handoff checklist for documentation and template maintenance.

Scope:
- documentation only
- no secrets
- no personal data
- no system changes