### PR TITLE
docs: add scoped review checklist

### DIFF
--- a/docs/scoped-review-checklist.md
+++ b/docs/scoped-review-checklist.md
@@ -1,0 +1,24 @@
+# Scoped review checklist
+
+Use this checklist when reviewing a small scoped repository change.
+
+## Scope
+
+- Confirm that the change has one clear purpose.
+- Confirm that the pull request title matches the diff.
+- Confirm that only expected files changed.
+- Confirm that no unrelated cleanup was included.
+
+## Content
+
+- Confirm that documentation wording is clear.
+- Confirm that private context was not added.
+- Confirm that no secrets or personal data were added.
+- Confirm that the commit message describes the change.
+
+## Merge path
+
+- Wait for checks before merge.
+- Confirm that the review approval is intentional.
+- Confirm that the head commit matches the expected commit.
+- Keep follow-up work for a separate branch.


### PR DESCRIPTION
Adds a small scoped review checklist for documentation and template maintenance.

Scope:
- documentation only
- no secrets
- no personal data
- no system changes