### PR TITLE
docs: add maintainer review window

### DIFF
--- a/docs/maintainer-review-window.md
+++ b/docs/maintainer-review-window.md
@@ -1,0 +1,24 @@
+# Maintainer review window
+
+Use these notes to keep a small maintainer review focused.
+
+## Review window
+
+- Confirm that the pull request has one clear goal.
+- Confirm that the branch starts from current upstream main.
+- Confirm that the changed file is expected.
+- Confirm that the diff is small enough to review.
+
+## Maintainer checks
+
+- Check that the title matches the change.
+- Check that the body states the documentation-only scope.
+- Check that no secrets or personal data were added.
+- Check that private context was not copied into the repository.
+
+## Decision
+
+- Approve only after checks complete.
+- Merge only with the expected head commit.
+- Keep follow-up work in a separate branch.
+- Leave the review trail easy to audit.


### PR DESCRIPTION
Adds small maintainer review window notes for documentation and template maintenance.

Scope:
- documentation only
- no secrets
- no personal data
- no system changes