### PR TITLE
docs: add daily review closeout plan

### DIFF
--- a/docs/daily-review-closeout-plan.md
+++ b/docs/daily-review-closeout-plan.md
@@ -1,0 +1,24 @@
+# Daily review closeout plan
+
+Use this plan when closing a focused review session.
+
+## Final review
+
+- Confirm that the pull request has one clear scope.
+- Confirm that the changed file is expected.
+- Confirm that checks completed successfully.
+- Confirm that the approval was intentional.
+
+## Closeout checks
+
+- Confirm that no secrets or personal data were added.
+- Confirm that private context was not copied into documentation.
+- Confirm that follow-up work remains separate.
+- Confirm that the merge used the expected head commit.
+
+## Next step
+
+- Return to current upstream main.
+- Start the next task on a new branch.
+- Keep the next change small and auditable.
+- Stop when the repository state is clean.


### PR DESCRIPTION
Adds a small daily review closeout plan for documentation and template maintenance.

Scope:
- documentation only
- no secrets
- no personal data
- no system changes