### PR TITLE
docs: add approval closeout notes

### DIFF
--- a/docs/approval-closeout-notes.md
+++ b/docs/approval-closeout-notes.md
@@ -1,0 +1,24 @@
+# Approval closeout notes
+
+Use these notes after approving a small documentation pull request.
+
+## Approval check
+
+- Confirm that the approval matches the reviewed diff.
+- Confirm that the pull request has one clear scope.
+- Confirm that checks completed successfully.
+- Confirm that the expected head commit is still current.
+
+## Merge check
+
+- Confirm that the merge method is intentional.
+- Confirm that the change is documentation only when stated.
+- Confirm that no secrets or personal data were added.
+- Confirm that private context was not copied into the repository.
+
+## Closeout
+
+- Confirm that the pull request is closed as merged.
+- Confirm that main contains the expected merge commit.
+- Keep follow-up work in a separate branch.
+- Leave the repository clean for the next task.


### PR DESCRIPTION
Adds small approval closeout notes for documentation and template maintenance.

Scope:
- documentation only
- no secrets
- no personal data
- no system changes