### PR TITLE
docs: add final maintenance handoff

### DIFF
--- a/docs/final-maintenance-handoff.md
+++ b/docs/final-maintenance-handoff.md
@@ -1,0 +1,24 @@
+# Final maintenance handoff
+
+Use this handoff when closing a focused repository maintenance session.
+
+## Final state
+
+- Confirm that the last pull request was merged.
+- Confirm that main contains the expected merge commit.
+- Confirm that the local main branch is current.
+- Confirm that the working tree is clean.
+
+## Handoff record
+
+- Keep the pull request trail easy to audit.
+- Keep the documentation-only scope visible.
+- Keep secrets and personal data out of the repository.
+- Keep private context out of committed files.
+
+## Next session
+
+- Start from current upstream main.
+- Use a new branch for the next focused change.
+- Keep follow-up work separate.
+- Stop when the repository is clean and understandable.


### PR DESCRIPTION
Adds a small final maintenance handoff for documentation and template maintenance.

Scope:
- documentation only
- no secrets
- no personal data
- no system changes