### PR TITLE
docs: add daily review record

### DIFF
--- a/docs/daily-review-record.md
+++ b/docs/daily-review-record.md
@@ -1,0 +1,24 @@
+# Daily review record
+
+Use this record to keep a focused maintenance review easy to follow.
+
+## Review start
+
+- Confirm that upstream main is current.
+- Confirm that the local main branch is clean.
+- Confirm that the new branch has one clear purpose.
+- Confirm that the planned change is documentation only.
+
+## Review evidence
+
+- Record the pull request title.
+- Record the changed file.
+- Record that no secrets or personal data were added.
+- Record that private context stayed out of the repository.
+
+## Review close
+
+- Wait for checks before merge.
+- Merge only after approval.
+- Confirm that main contains the expected merge commit.
+- Leave follow-up work for a separate branch.


### PR DESCRIPTION
Adds a small daily review record for documentation and template maintenance.

Scope:
- documentation only
- no secrets
- no personal data
- no system changes