### PR TITLE
docs: add review session log

### DIFF
--- a/docs/review-session-log.md
+++ b/docs/review-session-log.md
@@ -1,0 +1,24 @@
+# Review session log
+
+Use this log to keep a small review session easy to reconstruct.
+
+## Session start
+
+- Confirm that upstream main is current.
+- Confirm that the local main branch is clean.
+- Confirm that the task branch has one clear purpose.
+- Confirm that the planned change is documentation only.
+
+## Session evidence
+
+- Record the changed file.
+- Record that the pull request title matches the diff.
+- Record that no secrets or personal data were added.
+- Record that private context stayed out of committed files.
+
+## Session close
+
+- Wait for checks before approval.
+- Merge only after review.
+- Confirm that main contains the expected merge commit.
+- Leave follow-up work for a separate branch.


### PR DESCRIPTION
Adds a small review session log for documentation and template maintenance.

Scope:
- documentation only
- no secrets
- no personal data
- no system changes