### PR TITLE
docs: add maintenance trail notes

### DIFF
--- a/docs/maintenance-trail-notes.md
+++ b/docs/maintenance-trail-notes.md
@@ -1,0 +1,24 @@
+# Maintenance trail notes
+
+Use these notes to keep a small maintenance trail easy to audit.
+
+## Trail start
+
+- Confirm that upstream main is current.
+- Confirm that the local main branch is clean.
+- Confirm that the new branch has one clear purpose.
+- Confirm that the planned change is small.
+
+## Trail evidence
+
+- Record the changed file.
+- Record that the pull request title matches the diff.
+- Record that no secrets or personal data were added.
+- Record that private context stayed out of repository files.
+
+## Trail close
+
+- Wait for checks before merge.
+- Merge only after review.
+- Confirm that main contains the expected merge commit.
+- Keep follow-up work for a separate branch.


### PR DESCRIPTION
Adds small maintenance trail notes for documentation and template maintenance.

Scope:
- documentation only
- no secrets
- no personal data
- no system changes