### PR TITLE
docs: add review closeout log

### DIFF
--- a/docs/review-closeout-log.md
+++ b/docs/review-closeout-log.md
@@ -1,0 +1,24 @@
+# Review closeout log
+
+Use this log to close a small review cycle with a clear record.
+
+## Closeout start
+
+- Confirm that the pull request has one clear purpose.
+- Confirm that the changed file is expected.
+- Confirm that checks completed successfully.
+- Confirm that approval matches the reviewed diff.
+
+## Closeout evidence
+
+- Record that the change is documentation only.
+- Record that no secrets or personal data were added.
+- Record that private context stayed out of repository files.
+- Record that follow-up work remains separate.
+
+## Closeout finish
+
+- Confirm that the merge used the expected head commit.
+- Confirm that main contains the merge commit.
+- Return to current upstream main before new work.
+- Leave the repository ready for the next focused task.


### PR DESCRIPTION
Adds a small review closeout log for documentation and template maintenance.

Scope:
- documentation only
- no secrets
- no personal data
- no system changes