### PR TITLE
docs: add maintainer evidence log

### DIFF
--- a/docs/maintainer-evidence-log.md
+++ b/docs/maintainer-evidence-log.md
@@ -1,0 +1,24 @@
+# Maintainer evidence log
+
+Use this log to keep maintainer review evidence clear for small changes.
+
+## Evidence start
+
+- Confirm that upstream main is current.
+- Confirm that the local main branch is clean.
+- Confirm that the branch has one clear purpose.
+- Confirm that the planned change is documentation only.
+
+## Evidence review
+
+- Record the changed file.
+- Record that the pull request title matches the diff.
+- Record that no secrets or personal data were added.
+- Record that private context stayed out of repository files.
+
+## Evidence finish
+
+- Wait for checks before approval.
+- Merge only after review.
+- Confirm that main contains the expected merge commit.
+- Keep follow-up work for a separate branch.


### PR DESCRIPTION
Adds a small maintainer evidence log for documentation and template maintenance.

Scope:
- documentation only
- no secrets
- no personal data
- no system changes