### PR TITLE
docs: add review continuity log

### DIFF
--- a/docs/review-continuity-log.md
+++ b/docs/review-continuity-log.md
@@ -1,0 +1,24 @@
+# Review continuity log
+
+Use this log to keep review continuity clear across small maintenance changes.
+
+## Continuity start
+
+- Confirm that upstream main is current.
+- Confirm that the local main branch is clean.
+- Confirm that the new branch has one clear purpose.
+- Confirm that the planned change is documentation only.
+
+## Continuity evidence
+
+- Record the changed file.
+- Record that the pull request title matches the diff.
+- Record that no secrets or personal data were added.
+- Record that private context stayed out of repository files.
+
+## Continuity close
+
+- Wait for checks before approval.
+- Merge only after review.
+- Confirm that main contains the expected merge commit.
+- Keep follow-up work for a separate branch.


### PR DESCRIPTION
Adds small review continuity notes for documentation and template maintenance.

Scope:
- documentation only
- no secrets
- no personal data
- no system changes