### PR TITLE
docs: add merge evidence checklist

### DIFF
--- a/docs/merge-evidence-checklist.md
+++ b/docs/merge-evidence-checklist.md
@@ -1,0 +1,24 @@
+# Merge evidence checklist
+
+Use this checklist to verify evidence before merging a small documentation pull request.
+
+## Before merge
+
+- Confirm that the pull request has one clear purpose.
+- Confirm that the changed file is expected.
+- Confirm that checks completed successfully.
+- Confirm that the review approval matches the diff.
+
+## Evidence
+
+- Confirm that the change is documentation only.
+- Confirm that no secrets or personal data were added.
+- Confirm that private context stayed out of repository files.
+- Confirm that the expected head commit is still current.
+
+## After merge
+
+- Confirm that the pull request is closed as merged.
+- Confirm that main contains the expected merge commit.
+- Keep follow-up work for a separate branch.
+- Leave the repository ready for the next focused task.


### PR DESCRIPTION
Adds a small merge evidence checklist for documentation and template maintenance.

Scope:
- documentation only
- no secrets
- no personal data
- no system changes