### PR TITLE
docs: add final review evidence log

### DIFF
--- a/docs/final-review-evidence-log.md
+++ b/docs/final-review-evidence-log.md
@@ -1,0 +1,24 @@
+# Final review evidence log
+
+Use this log to keep final review evidence clear for a small documentation change.
+
+## Final review start
+
+- Confirm that upstream main is current.
+- Confirm that the local main branch is clean.
+- Confirm that the branch has one clear purpose.
+- Confirm that the planned change is documentation only.
+
+## Final review evidence
+
+- Record the changed file.
+- Record that the pull request title matches the diff.
+- Record that no secrets or personal data were added.
+- Record that private context stayed out of repository files.
+
+## Final review close
+
+- Wait for checks before approval.
+- Merge only after review.
+- Confirm that main contains the expected merge commit.
+- Keep follow-up work for a separate branch.


### PR DESCRIPTION
Adds a small final review evidence log for documentation and template maintenance.

Scope:
- documentation only
- no secrets
- no personal data
- no system changes