### PR TITLE
docs: add final maintenance record

### DIFF
--- a/docs/final-maintenance-record.md
+++ b/docs/final-maintenance-record.md
@@ -1,0 +1,24 @@
+# Final maintenance record
+
+Use this record to close a focused maintenance change with a clear trail.
+
+## Record start
+
+- Confirm that upstream main is current.
+- Confirm that the local main branch is clean.
+- Confirm that the branch has one clear purpose.
+- Confirm that the planned change is documentation only.
+
+## Record evidence
+
+- Record the changed file.
+- Record that the pull request title matches the diff.
+- Record that no secrets or personal data were added.
+- Record that private context stayed out of repository files.
+
+## Record close
+
+- Wait for checks before approval.
+- Merge only after review.
+- Confirm that main contains the expected merge commit.
+- Keep follow-up work for a separate branch.


### PR DESCRIPTION
Adds a small final maintenance record for documentation and template maintenance.

Scope:
- documentation only
- no secrets
- no personal data
- no system changes