### PR TITLE
docs: add maintenance session evidence

### DIFF
--- a/docs/maintenance-session-evidence.md
+++ b/docs/maintenance-session-evidence.md
@@ -1,0 +1,24 @@
+# Maintenance session evidence
+
+Use this evidence record to close a small maintenance session cleanly.
+
+## Session start
+
+- Confirm that upstream main is current.
+- Confirm that the local main branch is clean.
+- Confirm that the branch has one clear purpose.
+- Confirm that the planned change is documentation only.
+
+## Evidence record
+
+- Record the changed file.
+- Record that the pull request title matches the diff.
+- Record that no secrets or personal data were added.
+- Record that private context stayed out of repository files.
+
+## Session close
+
+- Wait for checks before approval.
+- Merge only after review.
+- Confirm that main contains the expected merge commit.
+- Keep follow-up work for a separate branch.


### PR DESCRIPTION
Adds small maintenance session evidence notes for documentation and template maintenance.

Scope:
- documentation only
- no secrets
- no personal data
- no system changes