### PR TITLE
docs: add maintenance completion log

### DIFF
--- a/docs/maintenance-completion-log.md
+++ b/docs/maintenance-completion-log.md
@@ -1,0 +1,24 @@
+# Maintenance completion log
+
+Use this log to close a focused maintenance run with a clear final record.
+
+## Completion start
+
+- Confirm that upstream main is current.
+- Confirm that the local main branch is clean.
+- Confirm that the branch has one clear purpose.
+- Confirm that the planned change is documentation only.
+
+## Completion evidence
+
+- Record the changed file.
+- Record that the pull request title matches the diff.
+- Record that no secrets or personal data were added.
+- Record that private context stayed out of repository files.
+
+## Completion close
+
+- Wait for checks before approval.
+- Merge only after review.
+- Confirm that main contains the expected merge commit.
+- Keep follow-up work for a separate branch.


### PR DESCRIPTION
Adds a small maintenance completion log for documentation and template maintenance.

Scope:
- documentation only
- no secrets
- no personal data
- no system changes