### PR TITLE
docs: add handoff review log

### DIFF
--- a/docs/handoff-review-log.md
+++ b/docs/handoff-review-log.md
@@ -1,0 +1,24 @@
+# Handoff review log
+
+Use this log to keep a small handoff review clear and easy to verify.
+
+## Handoff start
+
+- Confirm that upstream main is current.
+- Confirm that the local main branch is clean.
+- Confirm that the branch has one clear purpose.
+- Confirm that the planned change is documentation only.
+
+## Handoff evidence
+
+- Record the changed file.
+- Record that the pull request title matches the diff.
+- Record that no secrets or personal data were added.
+- Record that private context stayed out of repository files.
+
+## Handoff close
+
+- Wait for checks before approval.
+- Merge only after review.
+- Confirm that main contains the expected merge commit.
+- Keep follow-up work for a separate branch.


### PR DESCRIPTION
Adds a small handoff review log for documentation and template maintenance.

Scope:
- documentation only
- no secrets
- no personal data
- no system changes