### PR TITLE
docs: add clean handoff record

### DIFF
--- a/docs/clean-handoff-record.md
+++ b/docs/clean-handoff-record.md
@@ -1,0 +1,24 @@
+# Clean handoff record
+
+Use this record to keep a small handoff clean, focused, and easy to review.
+
+## Clean handoff start
+
+- Confirm that upstream main is current.
+- Confirm that the local main branch is clean.
+- Confirm that the branch has one clear purpose.
+- Confirm that the planned change is documentation only.
+
+## Clean handoff evidence
+
+- Record the changed file.
+- Record that the pull request title matches the diff.
+- Record that no secrets or personal data were added.
+- Record that private context stayed out of repository files.
+
+## Clean handoff close
+
+- Wait for checks before approval.
+- Merge only after review.
+- Confirm that main contains the expected merge commit.
+- Keep follow-up work for a separate branch.


### PR DESCRIPTION
Adds a small clean handoff record for documentation and template maintenance.

Scope:
- documentation only
- no secrets
- no personal data
- no system changes