### PR TITLE
docs: add focused closeout record

### DIFF
--- a/docs/focused-closeout-record.md
+++ b/docs/focused-closeout-record.md
@@ -1,0 +1,24 @@
+# Focused closeout record
+
+Use this record to close a small documentation change with a focused trail.
+
+## Focused start
+
+- Confirm that upstream main is current.
+- Confirm that the local main branch is clean.
+- Confirm that the branch has one clear purpose.
+- Confirm that the planned change is documentation only.
+
+## Focused evidence
+
+- Record the changed file.
+- Record that the pull request title matches the diff.
+- Record that no secrets or personal data were added.
+- Record that private context stayed out of repository files.
+
+## Focused close
+
+- Wait for checks before approval.
+- Merge only after review.
+- Confirm that main contains the expected merge commit.
+- Keep follow-up work for a separate branch.


### PR DESCRIPTION
Adds a small focused closeout record for documentation and template maintenance.

Scope:
- documentation only
- no secrets
- no personal data
- no system changes