### PR TITLE
docs: add simple review trail

### DIFF
--- a/docs/simple-review-trail.md
+++ b/docs/simple-review-trail.md
@@ -1,0 +1,24 @@
+# Simple review trail
+
+Use this trail to keep a small documentation review simple and auditable.
+
+## Simple start
+
+- Confirm that upstream main is current.
+- Confirm that the local main branch is clean.
+- Confirm that the branch has one clear purpose.
+- Confirm that the planned change is documentation only.
+
+## Simple evidence
+
+- Record the changed file.
+- Record that the pull request title matches the diff.
+- Record that no secrets or personal data were added.
+- Record that private context stayed out of repository files.
+
+## Simple close
+
+- Wait for checks before approval.
+- Merge only after review.
+- Confirm that main contains the expected merge commit.
+- Keep follow-up work for a separate branch.


### PR DESCRIPTION
Adds a small simple review trail for documentation and template maintenance.

Scope:
- documentation only
- no secrets
- no personal data
- no system changes