### PR TITLE
docs: add quiet closeout notes

### DIFF
--- a/docs/quiet-closeout-notes.md
+++ b/docs/quiet-closeout-notes.md
@@ -1,0 +1,24 @@
+# Quiet closeout notes
+
+Use these notes to close a small documentation change without adding noise.
+
+## Quiet closeout start
+
+- Confirm that upstream main is current.
+- Confirm that the local main branch is clean.
+- Confirm that the branch has one clear purpose.
+- Confirm that the planned change is documentation only.
+
+## Quiet closeout evidence
+
+- Record the changed file.
+- Record that the pull request title matches the diff.
+- Record that no secrets or personal data were added.
+- Record that private context stayed out of repository files.
+
+## Quiet closeout finish
+
+- Wait for checks before approval.
+- Merge only after review.
+- Confirm that main contains the expected merge commit.
+- Keep follow-up work for a separate branch.


### PR DESCRIPTION
Adds small quiet closeout notes for documentation and template maintenance.

Scope:
- documentation only
- no secrets
- no personal data
- no system changes