### PR TITLE
docs: add review closeout trail

### DIFF
--- a/docs/review-closeout-trail.md
+++ b/docs/review-closeout-trail.md
@@ -1,0 +1,24 @@
+# Review closeout trail
+
+Use this trail to close a small review with clear evidence and minimal noise.
+
+## Closeout start
+
+- Confirm that upstream main is current.
+- Confirm that the local main branch is clean.
+- Confirm that the branch has one clear purpose.
+- Confirm that the planned change is documentation only.
+
+## Closeout evidence
+
+- Record the changed file.
+- Record that the pull request title matches the diff.
+- Record that no secrets or personal data were added.
+- Record that private context stayed out of repository files.
+
+## Closeout finish
+
+- Wait for checks before approval.
+- Merge only after review.
+- Confirm that main contains the expected merge commit.
+- Keep follow-up work for a separate branch.


### PR DESCRIPTION
Adds a small review closeout trail for documentation and template maintenance.

Scope:
- documentation only
- no secrets
- no personal data
- no system changes