### PR TITLE
docs: add final review closeout record

### DIFF
--- a/docs/final-review-closeout-record.md
+++ b/docs/final-review-closeout-record.md
@@ -1,0 +1,24 @@
+# Final review closeout record
+
+Use this record to close a final small review with clear evidence.
+
+## Final closeout start
+
+- Confirm that upstream main is current.
+- Confirm that the local main branch is clean.
+- Confirm that the branch has one clear purpose.
+- Confirm that the planned change is documentation only.
+
+## Final closeout evidence
+
+- Record the changed file.
+- Record that the pull request title matches the diff.
+- Record that no secrets or personal data were added.
+- Record that private context stayed out of repository files.
+
+## Final closeout finish
+
+- Wait for checks before approval.
+- Merge only after review.
+- Confirm that main contains the expected merge commit.
+- Keep follow-up work for a separate branch.


### PR DESCRIPTION
Adds a small final review closeout record for documentation and template maintenance.

Scope:
- documentation only
- no secrets
- no personal data
- no system changes