### PR TITLE
docs: add review readiness record

### DIFF
--- a/docs/review-readiness-record.md
+++ b/docs/review-readiness-record.md
@@ -1,0 +1,24 @@
+# Review readiness record
+
+Use this record to keep a small review ready for a clean close.
+
+## Readiness start
+
+- Confirm that upstream main is current.
+- Confirm that the local main branch is clean.
+- Confirm that the branch has one clear purpose.
+- Confirm that the planned change is documentation only.
+
+## Readiness evidence
+
+- Record the changed file.
+- Record that the pull request title matches the diff.
+- Record that no secrets or personal data were added.
+- Record that private context stayed out of repository files.
+
+## Readiness close
+
+- Wait for checks before approval.
+- Merge only after review.
+- Confirm that main contains the expected merge commit.
+- Keep follow-up work for a separate branch.


### PR DESCRIPTION
Adds a small review readiness record for documentation and template maintenance.

Scope:
- documentation only
- no secrets
- no personal data
- no system changes