### PR TITLE
docs: add steady closeout record

### DIFF
--- a/docs/steady-closeout-record.md
+++ b/docs/steady-closeout-record.md
@@ -1,0 +1,24 @@
+# Steady closeout record
+
+Use this record to close a small maintenance review with a steady trail.
+
+## Steady closeout start
+
+- Confirm that upstream main is current.
+- Confirm that the local main branch is clean.
+- Confirm that the branch has one clear purpose.
+- Confirm that the planned change is documentation only.
+
+## Steady closeout evidence
+
+- Record the changed file.
+- Record that the pull request title matches the diff.
+- Record that no secrets or personal data were added.
+- Record that private context stayed out of repository files.
+
+## Steady closeout finish
+
+- Wait for checks before approval.
+- Merge only after review.
+- Confirm that main contains the expected merge commit.
+- Keep follow-up work for a separate branch.


### PR DESCRIPTION
Adds a small steady closeout record for documentation and template maintenance.

Scope:
- documentation only
- no secrets
- no personal data
- no system changes