### PR TITLE
docs: add stable review record

### DIFF
--- a/docs/stable-review-record.md
+++ b/docs/stable-review-record.md
@@ -1,0 +1,24 @@
+# Stable review record
+
+Use this record to keep a small documentation review stable and easy to verify.
+
+## Stable start
+
+- Confirm that upstream main is current.
+- Confirm that the local main branch is clean.
+- Confirm that the branch has one clear purpose.
+- Confirm that the planned change is documentation only.
+
+## Stable evidence
+
+- Record the changed file.
+- Record that the pull request title matches the diff.
+- Record that no secrets or personal data were added.
+- Record that private context stayed out of repository files.
+
+## Stable finish
+
+- Wait for checks before approval.
+- Merge only after review.
+- Confirm that main contains the expected merge commit.
+- Keep follow-up work for a separate branch.


### PR DESCRIPTION
Adds a small stable review record for documentation and template maintenance.

Scope:
- documentation only
- no secrets
- no personal data
- no system changes