### PR TITLE
docs: add calm review record

### DIFF
--- a/docs/calm-review-record.md
+++ b/docs/calm-review-record.md
@@ -1,0 +1,24 @@
+# Calm review record
+
+Use this record to keep a small documentation review calm and easy to close.
+
+## Calm start
+
+- Confirm that upstream main is current.
+- Confirm that the local main branch is clean.
+- Confirm that the branch has one clear purpose.
+- Confirm that the planned change is documentation only.
+
+## Calm evidence
+
+- Record the changed file.
+- Record that the pull request title matches the diff.
+- Record that no secrets or personal data were added.
+- Record that private context stayed out of repository files.
+
+## Calm finish
+
+- Wait for checks before approval.
+- Merge only after review.
+- Confirm that main contains the expected merge commit.
+- Keep follow-up work for a separate branch.


### PR DESCRIPTION
Adds a small calm review record for documentation and template maintenance.

Scope:
- documentation only
- no secrets
- no personal data
- no system changes