### PR TITLE
docs: add quiet review checklist

### DIFF
--- a/docs/quiet-review-checklist.md
+++ b/docs/quiet-review-checklist.md
@@ -1,0 +1,24 @@
+# Quiet review checklist
+
+Use this checklist to keep a small documentation review quiet and easy to verify.
+
+## Quiet checklist start
+
+- Confirm that upstream main is current.
+- Confirm that the local main branch is clean.
+- Confirm that the branch has one clear purpose.
+- Confirm that the planned change is documentation only.
+
+## Quiet checklist evidence
+
+- Record the changed file.
+- Record that the pull request title matches the diff.
+- Record that no secrets or personal data were added.
+- Record that private context stayed out of repository files.
+
+## Quiet checklist finish
+
+- Wait for checks before approval.
+- Merge only after review.
+- Confirm that main contains the expected merge commit.
+- Keep follow-up work for a separate branch.


### PR DESCRIPTION
Adds a small quiet review checklist for documentation and template maintenance.

Scope:
- documentation only
- no secrets
- no personal data
- no system changes