### PR TITLE
docs: add measured review record

### DIFF
--- a/docs/measured-review-record.md
+++ b/docs/measured-review-record.md
@@ -1,0 +1,24 @@
+# Measured review record
+
+Use this record to keep a small documentation review measured and easy to close.
+
+## Measured start
+
+- Confirm that upstream main is current.
+- Confirm that the local main branch is clean.
+- Confirm that the branch has one clear purpose.
+- Confirm that the planned change is documentation only.
+
+## Measured evidence
+
+- Record the changed file.
+- Record that the pull request title matches the diff.
+- Record that no secrets or personal data were added.
+- Record that private context stayed out of repository files.
+
+## Measured finish
+
+- Wait for checks before approval.
+- Merge only after review.
+- Confirm that main contains the expected merge commit.
+- Keep follow-up work for a separate branch.


### PR DESCRIPTION
Adds a small measured review record for documentation and template maintenance.

Scope:
- documentation only
- no secrets
- no personal data
- no system changes