### PR TITLE
docs: add plain review record

### DIFF
--- a/docs/plain-review-record.md
+++ b/docs/plain-review-record.md
@@ -1,0 +1,24 @@
+# Plain review record
+
+Use this record to keep a small documentation review plain and easy to verify.
+
+## Plain start
+
+- Confirm that upstream main is current.
+- Confirm that the local main branch is clean.
+- Confirm that the branch has one clear purpose.
+- Confirm that the planned change is documentation only.
+
+## Plain evidence
+
+- Record the changed file.
+- Record that the pull request title matches the diff.
+- Record that no secrets or personal data were added.
+- Record that private context stayed out of repository files.
+
+## Plain finish
+
+- Wait for checks before approval.
+- Merge only after review.
+- Confirm that main contains the expected merge commit.
+- Keep follow-up work for a separate branch.


### PR DESCRIPTION
Adds a small plain review record for documentation and template maintenance.

Scope:
- documentation only
- no secrets
- no personal data
- no system changes