### PR TITLE
docs: add final evidence checklist

### DIFF
--- a/docs/final-evidence-checklist.md
+++ b/docs/final-evidence-checklist.md
@@ -1,0 +1,24 @@
+# Final evidence checklist
+
+Use this checklist to keep a final small review clear and easy to verify.
+
+## Final checklist start
+
+- Confirm that upstream main is current.
+- Confirm that the local main branch is clean.
+- Confirm that the branch has one clear purpose.
+- Confirm that the planned change is documentation only.
+
+## Final checklist evidence
+
+- Record the changed file.
+- Record that the pull request title matches the diff.
+- Record that no secrets or personal data were added.
+- Record that private context stayed out of repository files.
+
+## Final checklist finish
+
+- Wait for checks before approval.
+- Merge only after review.
+- Confirm that main contains the expected merge commit.
+- Keep follow-up work for a separate branch.


### PR DESCRIPTION
Adds a small final evidence checklist for documentation and template maintenance.

Scope:
- documentation only
- no secrets
- no personal data
- no system changes