### PR TITLE
docs: add closing review checklist

### DIFF
--- a/docs/closing-review-checklist.md
+++ b/docs/closing-review-checklist.md
@@ -1,0 +1,24 @@
+# Closing review checklist
+
+Use this checklist to close a small documentation review with a clear final trail.
+
+## Closing checklist start
+
+- Confirm that upstream main is current.
+- Confirm that the local main branch is clean.
+- Confirm that the branch has one clear purpose.
+- Confirm that the planned change is documentation only.
+
+## Closing checklist evidence
+
+- Record the changed file.
+- Record that the pull request title matches the diff.
+- Record that no secrets or personal data were added.
+- Record that private context stayed out of repository files.
+
+## Closing checklist finish
+
+- Wait for checks before approval.
+- Merge only after review.
+- Confirm that main contains the expected merge commit.
+- Keep follow-up work for a separate branch.


### PR DESCRIPTION
Adds a small closing review checklist for documentation and template maintenance.

Scope:
- documentation only
- no secrets
- no personal data
- no system changes